### PR TITLE
Example for change of engine option UCI_Chess960

### DIFF
--- a/uci-specification.txt
+++ b/uci-specification.txt
@@ -528,7 +528,8 @@ the engine that is should play according to the Chess960 rules.
 This is done by the special engine option UCI_Chess960. If the engine knows about Chess960
 it should send the command 'option name UCI_Chess960 type check default false'
 to the GUI at program startup.
-Whenever a Chess960 game is played, the GUI should set this engine option to 'true'.
+Whenever a Chess960 game is played, the GUI should set this engine option to 'true':
+setoption name UCI_Chess960 value true
 
 Castling is different in Chess960 and the white king move when castling short is not always e1g1.
 A king move could both be the castling king move or just a normal king move.


### PR DESCRIPTION
Due to a recent issue regarding this engine option in Stockfish I consider the description of the UCI specification unsatisfactory with respect to the engine option UCI_Chess960. In the part "Chess960" it is said that this engine option should be set to true.
To make this immediately clear the command to change this engine option should be explicitly given, i.e. the following text update is proposed:
-----
Whenever a Chess960 game is played, the GUI should set this engine option to 'true':
setoption name UCI_Chess960 value true
-----
I do not see any strong arguments against such update and for me this would be the logic consequence, too, since the related engine message 'option name UCI_Chess960 type check default false' has been mentioned before. Last but not least, it would directly answer any questions how to do it, in particular coming from such users with still limited knowledge of UCI specification.